### PR TITLE
added override for trivy repo to fix rate limit issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,7 @@ workflows:
             - hmpps-common-vars
       - hmpps/trivy_latest_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          additional_args: --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1
           context:
             - hmpps-common-vars
       - hmpps/veracode_pipeline_scan:


### PR DESCRIPTION
[See description here for more detail - identical to API trivy fix](https://github.com/ministryofjustice/hmpps-electronic-monitoring-datastore-api/pull/19)