### PR TITLE
remove searchForOrder from code base

### DIFF
--- a/integration_tests/e2e/searchResults.cy.ts
+++ b/integration_tests/e2e/searchResults.cy.ts
@@ -1,63 +1,64 @@
-import SearchResultsPage from '../pages/searchResults'
-import Page from '../pages/page'
+// TODO: SearchResults test: A new integration test is needed for
+// import SearchResultsPage from '../pages/searchResults'
+// import Page from '../pages/page'
 
-context('SearchResults', () => {
-  beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.signIn()
-    cy.visit('/search/results')
-  })
+// context('SearchResults', () => {
+//   beforeEach(() => {
+//     cy.task('reset')
+//     cy.task('stubSignIn')
+//     cy.signIn()
+//     cy.visit('/search/results')
+//   })
 
-  it('is reachable', () => {
-    Page.verifyOnPage(SearchResultsPage)
-  })
+//   it('is reachable', () => {
+//     Page.verifyOnPage(SearchResultsPage)
+//   })
 
-  describe('Service information banner', () => {
-    it('Service information banner renders', () => {
-      const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-      searchResultsPage.serviceInformation().should('be.visible')
-    })
+//   describe('Service information banner', () => {
+//     it('Service information banner renders', () => {
+//       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+//       searchResultsPage.serviceInformation().should('be.visible')
+//     })
 
-    it('Service information banner text is correct', () => {
-      const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-      searchResultsPage
-        .serviceInformation()
-        .should('contain', 'This service gives you access to all order data that was held by Capita and G4S.')
-    })
-  })
+//     it('Service information banner text is correct', () => {
+//       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+//       searchResultsPage
+//         .serviceInformation()
+//         .should('contain', 'This service gives you access to all order data that was held by Capita and G4S.')
+//     })
+//   })
 
-  describe('Search results table', () => {
-    it('The table renders', () => {
-      const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-      searchResultsPage.resultsTable().should('be.visible')
-    })
+//   describe('Search results table', () => {
+//     it('The table renders', () => {
+//       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+//       searchResultsPage.resultsTable().should('be.visible')
+//     })
 
-    it('The subject ID column header contains the correct text', () => {
-      const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-      searchResultsPage.subjectIdHeader().should('contain', 'Legacy subject ID')
-    })
+//     it('The subject ID column header contains the correct text', () => {
+//       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+//       searchResultsPage.subjectIdHeader().should('contain', 'Legacy subject ID')
+//     })
 
-    it('The name column header contains the correct text', () => {
-      const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-      searchResultsPage.nameHeader().should('contain', 'Name')
-    })
+//     it('The name column header contains the correct text', () => {
+//       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+//       searchResultsPage.nameHeader().should('contain', 'Name')
+//     })
 
-    it('The date of birth column header contains the correct text', () => {
-      const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-      searchResultsPage.dateOfBirthHeader().should('contain', 'Date of birth')
-    })
+//     it('The date of birth column header contains the correct text', () => {
+//       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+//       searchResultsPage.dateOfBirthHeader().should('contain', 'Date of birth')
+//     })
 
-    it('The order start date column header contains the correct text', () => {
-      const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-      searchResultsPage.orderStartDateHeader().should('contain', 'Order start date')
-    })
-  })
+//     it('The order start date column header contains the correct text', () => {
+//       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+//       searchResultsPage.orderStartDateHeader().should('contain', 'Order start date')
+//     })
+//   })
 
-  //   describe('Pagination', () => {
-  //     it('The pagination component renders', () => {
-  //       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-  //       searchResultsPage.pagination().should('be.visible')
-  //     })
-  //   })
-})
+//   //   describe('Pagination', () => {
+//   //     it('The pagination component renders', () => {
+//   //       const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+//   //       searchResultsPage.pagination().should('be.visible')
+//   //     })
+//   //   })
+// })

--- a/server/controllers/searchController.test.ts
+++ b/server/controllers/searchController.test.ts
@@ -12,17 +12,18 @@ import SearchOrderFormDataModel from '../models/form-data/searchOrder'
 jest.mock('../services/auditService')
 jest.mock('../services/datastoreSearchService')
 
-jest.mock('../utils/tabulateOrders', () => jest.fn(() => []))
+jest.mock('../utils/tabulateOrders', () => jest.fn((): unknown[] => []))
 jest.mock('../models/form-data/searchOrder')
 
 const hmppsAuthClient = createMockHmppsAuthClient()
 const datastoreClient = createDatastoreClient()
 const datastoreClientFactory = jest.fn()
 datastoreClientFactory.mockResolvedValue(datastoreClient)
-const auditService = new AuditService(null) as jest.Mocked<AuditService>
-const datastoreSearchService = new DatastoreSearchService(datastoreClientFactory, hmppsAuthClient)
+const auditService = {
+  logPageView: jest.fn(),
+} as unknown as AuditService
 
-datastoreSearchService.searchForOrders = jest.fn().mockResolvedValue(orders)
+const datastoreSearchService = new DatastoreSearchService(datastoreClientFactory, hmppsAuthClient)
 
 jest.mock('../models/view-models/searchForOrders')
 describe('SearchController', () => {

--- a/server/data/datastoreClient.ts
+++ b/server/data/datastoreClient.ts
@@ -36,16 +36,6 @@ export default class DatastoreClient {
     return results
   }
 
-  async searchForOrders(critera: Order): Promise<Order[]> {
-    // TODO: This method should be a post. criteria will be validated search formdata
-    // const results: Order[] = await this.restClient.get({
-    //   path: `ADD_CORRECT_PATH/criteria-object-here`,
-    // })
-
-    // TODO: return results from commented out API call, once API endpoint has been written
-    return orders
-  }
-
   async getCases(critera: Order): Promise<Order> {
     const result: Order = await this.restClient.get({
       path: `/search/cases/${critera.legacySubjectId}`,

--- a/server/routes/searchRouter.test.ts
+++ b/server/routes/searchRouter.test.ts
@@ -40,14 +40,3 @@ describe('Core page basic GET requests', () => {
     },
   )
 })
-
-describe('Search results page', () => {
-  it('should call the DatastoreSearchService to return data', () => {
-    return request(app)
-      .get('/search/results')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(datastoreSearchService.searchForOrders).toHaveBeenCalledTimes(1)
-      })
-  })
-})

--- a/server/routes/searchRouter.ts
+++ b/server/routes/searchRouter.ts
@@ -1,9 +1,6 @@
 import { type RequestHandler, Router } from 'express'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
-import { Page } from '../services/auditService'
-import tabulateOrders from '../utils/tabulateOrders'
-import { Order } from '../interfaces/order'
 import SearchController from '../controllers/searchController'
 
 export default function searchRouter({ auditService, datastoreSearchService }: Services): Router {

--- a/server/routes/searchRouter.ts
+++ b/server/routes/searchRouter.ts
@@ -13,31 +13,8 @@ export default function searchRouter({ auditService, datastoreSearchService }: S
 
   const searchController = new SearchController(auditService, datastoreSearchService)
 
-  // get('/', async (req, res, next) => {
-  //   await auditService.logPageView(Page.SEARCH_PAGE, { who: res.locals.user.username, correlationId: req.id })
-
-  //   res.render('pages/search')
-  // })
-
   get('/', searchController.search)
   post('/', searchController.view)
-
-  get('/results', async (req, res, next) => {
-    // TODO: replace this with FormData object
-    const searchItem: Order = {
-      dataType: 'am',
-      legacySubjectId: 1,
-    }
-    await auditService.logPageView(Page.SEARCH_RESULTS_PAGE, { who: res.locals.user.username, correlationId: req.id })
-
-    try {
-      const orders = await datastoreSearchService.searchForOrders(searchItem)
-      const tabulatedOrders = tabulateOrders(orders)
-      res.render('pages/searchResults', { data: tabulatedOrders })
-    } catch {
-      res.status(500).send('Error fetching data')
-    }
-  })
 
   return router
 }

--- a/server/services/datastoreOrderService.ts
+++ b/server/services/datastoreOrderService.ts
@@ -19,18 +19,6 @@ export default class DatastoreOrderService {
     this.datastoreClient = this.datastoreClientFactory('uninitialised')
   }
 
-  async getOrders(criteria: Order): Promise<Order[]> {
-    try {
-      this.datastoreClient.updateToken(await this.hmppsAuthClient.getSystemClientToken())
-
-      const results = this.datastoreClient.searchForOrders(criteria)
-      return results
-    } catch (error) {
-      logger.error(getSanitisedError(error), 'Error retrieving search results')
-      return error
-    }
-  }
-
   // place holder to ensure that we're returning something.
   // temporary before we wire up the api endpoints.
   // TODO: Add try ... catch here instead of bubbling all the way up to top level handler

--- a/server/services/datastoreSearchService.test.ts
+++ b/server/services/datastoreSearchService.test.ts
@@ -35,18 +35,6 @@ describe('Datastore Search Service', () => {
   })
 
   describe('getOrders', () => {
-    it('should return data from the client - `searchForOrders`', async () => {
-      const searchItem: Order = {
-        dataType: 'am',
-        legacySubjectId: 1,
-      }
-      const expectedData: Order[] = orders
-      datastoreClient.searchForOrders.mockResolvedValue(expectedData)
-
-      const results = await datastoreSearchService.searchForOrders(searchItem)
-      expect(results).toEqual(expectedData)
-    })
-
     it('should return data from the client - `searchOrders`', async () => {
       const searchOrder: SearchFormInput = {
         userToken: 'mockUserToken',

--- a/server/services/datastoreSearchService.ts
+++ b/server/services/datastoreSearchService.ts
@@ -20,18 +20,6 @@ export default class DatastoreSearchService {
     this.datastoreClient = this.datastoreClientFactory('uninitialised')
   }
 
-  async searchForOrders(criteria: Order): Promise<Order[]> {
-    try {
-      this.datastoreClient.updateToken(await this.hmppsAuthClient.getSystemClientToken())
-
-      const results = this.datastoreClient.searchForOrders(criteria)
-      return results
-    } catch (error) {
-      logger.error(getSanitisedError(error), 'Error retrieving search results')
-      return error
-    }
-  }
-
   async search(input: SearchFormInput): Promise<Order[] | ValidationResult> {
     const validationErrors: ValidationResult = []
 


### PR DESCRIPTION
`searchForOrders` was a function that returned mock data to the UI. `searchForOrders` and `getOrders` previously returned mocked data from within the UI. This is now wholly handled in the api and therefore the methods are redundant and removed to avoid confusion.

Also in this pr are:

- resolving some type issues in `searchController.test.ts`
- removed `searchForOrders` test in `searchRouter.test.ts`
- removed `getOrders` as it references `searchForOrders`
- removed code that was commented out and now no longer required
