### PR TITLE
Fix URL in suspension of visits back button.

### DIFF
--- a/server/controllers/suspensionOfVisitsController.test.ts
+++ b/server/controllers/suspensionOfVisitsController.test.ts
@@ -51,7 +51,7 @@ describe('SuspensionOfVisitsController', () => {
   const createViewData = (orderId: number, events: SuspensionOfVisitsViewEvent[]): SuspensionOfVisitsViewModel => {
     return {
       orderId,
-      backUrl: `/orders/${orderId}`,
+      backUrl: `/orders/${orderId}/summary`,
       events,
     }
   }
@@ -84,7 +84,7 @@ describe('SuspensionOfVisitsController', () => {
 
   it('should render the page with no data', async () => {
     const expectedViewModel = {
-      backUrl: `/orders/${testOrderId}`,
+      backUrl: `/orders/${testOrderId}/summary`,
       events: [] as SuspensionOfVisitsEvent[],
       orderId: testOrderId,
     }

--- a/server/models/view-models/suspensionOfVisits.ts
+++ b/server/models/view-models/suspensionOfVisits.ts
@@ -38,7 +38,7 @@ const parseEvents = (events: SuspensionOfVisitsEvent[]): SuspensionOfVisitsViewE
 const createViewModelFromApiDto = (orderId: number, events: SuspensionOfVisitsEvent[]): SuspensionOfVisitsViewModel => {
   return {
     orderId,
-    backUrl: `/orders/${orderId}`,
+    backUrl: `/orders/${orderId}/summary`,
     events: parseEvents(events),
   }
 }


### PR DESCRIPTION
The back button in the suspension of visits view incorrectly routed to `orders/${orderId}`.
It now routes to `orders/${orderId}/summary`