### PR TITLE
Enable prod

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-datastore-ui/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-datastore-ui/values.yaml
@@ -33,7 +33,7 @@ generic-service:
     TOKEN_VERIFICATION_ENABLED: 'true'
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/'
     AUDIT_SQS_REGION: 'eu-west-2'
-    AUDIT_SERVICE_NAME: 'UNASSIGNED' # Your audit service name
+    AUDIT_SERVICE_NAME: 'HMPPS529' # Your audit service name
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -51,9 +51,9 @@ generic-service:
     elasticache-redis:
       REDIS_HOST: 'primary_endpoint_address'
       REDIS_AUTH_TOKEN: 'auth_token'
-    #sqs-hmpps-audit-secret:
-    #  AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
-    #  AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
+    sqs-hmpps-audit-secret:
+     AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
+     AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
   allowlist:
     groups:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,7 +13,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     EM_DATASTORE_API_URL: "https://electronic-monitoring-datastore-api-dev.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: DEV
-    AUDIT_ENABLED: "false"
+    AUDIT_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,7 +13,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     EM_DATASTORE_API_URL: "https://electronic-monitoring-datastore-api-preprod.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: PRE-PRODUCTION
-    AUDIT_ENABLED: "false"
+    AUDIT_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,7 +10,8 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     EM_DATASTORE_API_URL: "https://electronic-monitoring-datastore-api.hmpps.service.justice.gov.uk"
-    AUDIT_ENABLED: "false"
+    ENVIRONMENT_NAME: PRODUCTION
+    AUDIT_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service


### PR DESCRIPTION
**PROD WILL NOT SUCCESSFULLY DEPLOY YET**

- Because: the hmpps_Auth values are misssing from the prod UI secret as the clients are not yet set up.
- Demonstration: Compare the `hmpps-electronic-monitoring-datastore-ui` secret values between namespaces `hmpps-electronic-monitoring-datastore-preprod` and `hmpps-electronic-monitoring-datastore-prod`