### PR TITLE
Create 'no results' messaging for timeline pages

### DIFF
--- a/integration_tests/e2e/order/curfew-timetable.cy.ts
+++ b/integration_tests/e2e/order/curfew-timetable.cy.ts
@@ -22,7 +22,7 @@ context('Crufew Timetable', () => {
     Page.verifyOnPage(CurfewTimetablePage)
   })
 
-  describe('Timetables', () => {
+  describe('No results message', () => {
     it('Renders when no timetable entries have been found', () => {
       cy.task('stubDatastoreGetCurfewTimetable', {
         httpStatus: 200,
@@ -33,7 +33,57 @@ context('Crufew Timetable', () => {
       cy.visit(`/orders/${orderId}/curfew-timetable`)
 
       const curfewTimetablePage = Page.verifyOnPage(CurfewTimetablePage)
-      curfewTimetablePage.curfewTimetable.should('not.be.visible')
+      curfewTimetablePage.noResultsHeading.should('be.visible')
+      curfewTimetablePage.noResultsMessage.should('be.visible')
+    })
+
+    it('Does not render when a timetable entry has been found', () => {
+      cy.task('stubDatastoreGetCurfewTimetable', {
+        httpStatus: 200,
+        orderId,
+        body: [
+          {
+            legacySubjectId: 123,
+            serviceId: 321,
+            serviceAddress1: 'address line 1',
+            serviceAddress2: 'address line 2',
+            serviceAddress3: 'address line 3',
+            serviceAddressPostcode: 'postcode',
+            serviceStartDate: '2002-05-22T01:01:01',
+            serviceEndDate: '2002-05-22T01:01:01',
+            curfewStartDate: '2002-05-22T01:01:01',
+            curfewEndDate: '2002-05-22T01:01:01',
+            monday: 1,
+            tuesday: 2,
+            wednesday: 3,
+            thursday: 4,
+            friday: 5,
+            saturday: 6,
+            sunday: 7,
+          },
+        ],
+      })
+
+      cy.visit(`/orders/${orderId}/curfew-timetable`)
+
+      const curfewTimetablePage = Page.verifyOnPage(CurfewTimetablePage)
+      curfewTimetablePage.noResultsHeading.should('not.exist')
+      curfewTimetablePage.noResultsMessage.should('not.exist')
+    })
+  })
+
+  describe('Timetables', () => {
+    it('Does not render when no timetable entries have been found', () => {
+      cy.task('stubDatastoreGetCurfewTimetable', {
+        httpStatus: 200,
+        orderId,
+        body: [],
+      })
+
+      cy.visit(`/orders/${orderId}/curfew-timetable`)
+
+      const curfewTimetablePage = Page.verifyOnPage(CurfewTimetablePage)
+      curfewTimetablePage.curfewTimetable.should('not.exist')
     })
 
     it('Renders when one timetable entry has been found', () => {

--- a/integration_tests/e2e/order/equipment-details.cy.ts
+++ b/integration_tests/e2e/order/equipment-details.cy.ts
@@ -22,7 +22,7 @@ context('Equipment Details', () => {
     Page.verifyOnPage(EquipmentDetailsPage)
   })
 
-  describe('Timetables', () => {
+  describe('No results message', () => {
     it('Renders when no timetable entries have been found', () => {
       cy.task('stubDatastoreGetEquipmentDetails', {
         httpStatus: 200,
@@ -33,10 +33,44 @@ context('Equipment Details', () => {
       cy.visit(`/orders/${orderId}/equipment-details`)
 
       const equipmentDetailsPage = Page.verifyOnPage(EquipmentDetailsPage)
-      equipmentDetailsPage.timeline.should('not.be.visible')
+      equipmentDetailsPage.noResultsHeading.should('be.visible')
+      equipmentDetailsPage.noResultsMessage.should('be.visible')
     })
 
-    it('Renders when no timetable entries have been found', () => {
+    it('Does not render when a timetable entry has been found', () => {
+      cy.task('stubDatastoreGetEquipmentDetails', {
+        httpStatus: 200,
+        orderId,
+        body: [
+          {
+            legacySubjectId: 123,
+            legacyOrderId: 321,
+            pid: {
+              id: '123456',
+              equipmentCategoryDescription: 'TEST_PID_DESCRIPTION',
+              installedDateTime: '2002-02-02T01:01:01',
+              removedDateTime: '2002-06-02T01:01:01',
+            },
+            hmu: {
+              id: '098765',
+              equipmentCategoryDescription: 'TEST_HMU_DESCRIPTION',
+              installedDateTime: '2002-02-02T01:01:01',
+              removedDateTime: '2002-06-02T01:01:01',
+            },
+          },
+        ],
+      })
+
+      cy.visit(`/orders/${orderId}/equipment-details`)
+
+      const equipmentDetailsPage = Page.verifyOnPage(EquipmentDetailsPage)
+      equipmentDetailsPage.noResultsHeading.should('not.exist')
+      equipmentDetailsPage.noResultsMessage.should('not.exist')
+    })
+  })
+
+  describe('Timetables', () => {
+    it('Does not render when no timetable entries have been found', () => {
       cy.task('stubDatastoreGetEquipmentDetails', {
         httpStatus: 200,
         orderId,
@@ -46,7 +80,7 @@ context('Equipment Details', () => {
       cy.visit(`/orders/${orderId}/equipment-details`)
 
       const equipmentDetailsPage = Page.verifyOnPage(EquipmentDetailsPage)
-      equipmentDetailsPage.timeline.should('not.be.visible')
+      equipmentDetailsPage.timeline.should('not.exist')
     })
 
     it('Renders when one timetable entry have been found', () => {

--- a/integration_tests/e2e/search.cy.ts
+++ b/integration_tests/e2e/search.cy.ts
@@ -23,7 +23,7 @@ context('Search', () => {
       const searchPage = Page.verifyOnPage(SearchPage)
       searchPage
         .serviceInformation()
-        .should('contain', 'This service gives you access to all order data that was held by Capita and G4S.')
+        .should('contain', 'This service gives you access to all order data that was held by Capita and G4S')
     })
   })
 

--- a/integration_tests/e2e/searchResults.cy.ts
+++ b/integration_tests/e2e/searchResults.cy.ts
@@ -33,7 +33,7 @@ context('SearchResults', () => {
         const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
         searchResultsPage
           .serviceInformation()
-          .should('contain', 'This service gives you access to all order data that was held by Capita and G4S.')
+          .should('contain', 'This service gives you access to all order data that was held by Capita and G4S')
       })
     })
 
@@ -103,7 +103,7 @@ context('SearchResults', () => {
         const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
         searchResultsPage
           .serviceInformation()
-          .should('contain', 'This service gives you access to all order data that was held by Capita and G4S.')
+          .should('contain', 'This service gives you access to all order data that was held by Capita and G4S')
       })
     })
 

--- a/integration_tests/pages/order/curfewTimetable.ts
+++ b/integration_tests/pages/order/curfewTimetable.ts
@@ -16,4 +16,12 @@ export default class CurfewTimetablePage extends Page {
   getCurfewTimetableItem(index: number): PageElement {
     return cy.get('.moj-timeline').find('.moj-timeline__item').eq(index)
   }
+
+  get noResultsHeading(): PageElement {
+    return cy.get('.no-results-heading')
+  }
+
+  get noResultsMessage(): PageElement {
+    return cy.get('.no-results-message')
+  }
 }

--- a/integration_tests/pages/order/equipmentDetails.ts
+++ b/integration_tests/pages/order/equipmentDetails.ts
@@ -16,4 +16,12 @@ export default class EquipmentDetailsPage extends Page {
   getTimelineItem(index: number): PageElement {
     return cy.get('.moj-timeline').find('.moj-timeline__item').eq(index)
   }
+
+  get noResultsHeading(): PageElement {
+    return cy.get('.no-results-heading')
+  }
+
+  get noResultsMessage(): PageElement {
+    return cy.get('.no-results-message')
+  }
 }

--- a/server/views/components/emsServiceInformation.njk
+++ b/server/views/components/emsServiceInformation.njk
@@ -3,7 +3,7 @@
 {% macro emsServiceInformation() %}
 
   {{ govukWarningText({
-    text: "This service gives you access to all order data that was held by Capita and G4S.",
+    text: "This service gives you access to all order data that was held by Capita and G4S",
     iconFallbackText: "Warning",
     classes: "service-information"
   }) }}

--- a/server/views/pages/order/curfew-timetable.njk
+++ b/server/views/pages/order/curfew-timetable.njk
@@ -21,6 +21,13 @@
     {{ heading }}
   </h1>
 
-  {{ emsEventTimeline(curfewTimetable) }}
+  {% if curfewTimetable|length %}
+    {{ emsDateFilter() }}
+    <hr class="govuk-section-break govuk-section-break--m">
+    {{ emsEventTimeline(curfewTimetable) }}
+  {% else %}
+    <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
+    <p>There are no {{ heading | lower }} associated with this order</p>
+  {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/curfew-timetable.njk
+++ b/server/views/pages/order/curfew-timetable.njk
@@ -26,8 +26,8 @@
     <hr class="govuk-section-break govuk-section-break--m">
     {{ emsEventTimeline(curfewTimetable) }}
   {% else %}
-    <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
-    <p>No {{ heading | lower }} information was found for this order</p>
+    <h3 class="govuk-heading-m no-results-heading">No {{ heading | lower }} found</h3>
+    <p class="no-results-message">No {{ heading | lower }} information was found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/curfew-timetable.njk
+++ b/server/views/pages/order/curfew-timetable.njk
@@ -27,7 +27,7 @@
     {{ emsEventTimeline(curfewTimetable) }}
   {% else %}
     <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
-    <p>There are no {{ heading | lower }} associated with this order</p>
+    <p>No {{ heading | lower }} information was found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/equipment-details.njk
+++ b/server/views/pages/order/equipment-details.njk
@@ -21,6 +21,13 @@
     {{ heading }}
   </h1>
 
-  {{ emsEventTimeline(equipmentDetails) }}
+  {% if equipmentDetails|length %}
+    {{ emsDateFilter() }}
+    <hr class="govuk-section-break govuk-section-break--m">
+    {{ emsEventTimeline(equipmentDetails) }}
+  {% else %}
+    <h3 class="govuk-heading-m">No events found</h3>
+    <p>No {{ heading | lower }} events are associated with this order</p>
+  {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/equipment-details.njk
+++ b/server/views/pages/order/equipment-details.njk
@@ -26,8 +26,8 @@
     <hr class="govuk-section-break govuk-section-break--m">
     {{ emsEventTimeline(equipmentDetails) }}
   {% else %}
-    <h3 class="govuk-heading-m">No events found</h3>
-    <p>No {{ heading | lower }} events are associated with this order</p>
+    <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
+    <p>There are no {{ heading | lower }} associated with this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/equipment-details.njk
+++ b/server/views/pages/order/equipment-details.njk
@@ -27,7 +27,7 @@
     {{ emsEventTimeline(equipmentDetails) }}
   {% else %}
     <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
-    <p>There are no {{ heading | lower }} associated with this order</p>
+    <p>No {{ heading | lower }} information was found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/equipment-details.njk
+++ b/server/views/pages/order/equipment-details.njk
@@ -26,8 +26,8 @@
     <hr class="govuk-section-break govuk-section-break--m">
     {{ emsEventTimeline(equipmentDetails) }}
   {% else %}
-    <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
-    <p>No {{ heading | lower }} information was found for this order</p>
+    <h3 class="govuk-heading-m no-results-heading">No {{ heading | lower }} found</h3>
+    <p class="no-results-message">No {{ heading | lower }} information was found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/event-history.njk
+++ b/server/views/pages/order/event-history.njk
@@ -22,10 +22,13 @@
   </h1>
   <p class="govuk-body">Violation alerts, monitoring events and contact history</p>
 
-  {{ emsDateFilter() }}
-
-  <hr class="govuk-section-break govuk-section-break--m">
-
+  {% if events|length %}
+    {{ emsDateFilter() }}
+    <hr class="govuk-section-break govuk-section-break--m">
   {{ emsEventTimeline(events) }}
+  {% else %}
+    <h3 class="govuk-heading-m">No events found</h3>
+    <p>There are no events associated with this order</p>
+  {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/event-history.njk
+++ b/server/views/pages/order/event-history.njk
@@ -27,8 +27,8 @@
     <hr class="govuk-section-break govuk-section-break--m">
   {{ emsEventTimeline(events) }}
   {% else %}
-    <h3 class="govuk-heading-m">No events found</h3>
-    <p>No events were found for this order</p>
+    <h3 class="govuk-heading-m no-results-heading">No events found</h3>
+    <p class="no-results-message">No events were found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/event-history.njk
+++ b/server/views/pages/order/event-history.njk
@@ -28,7 +28,7 @@
   {{ emsEventTimeline(events) }}
   {% else %}
     <h3 class="govuk-heading-m">No events found</h3>
-    <p>There are no events associated with this order</p>
+    <p>No events were found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/visit-details.njk
+++ b/server/views/pages/order/visit-details.njk
@@ -26,8 +26,8 @@
     <hr class="govuk-section-break govuk-section-break--m">
     {{ emsEventTimeline(visitDetails) }}
   {% else %}
-    <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
-    <p>No {{ heading | lower }} information was found for this order</p>
+    <h3 class="govuk-heading-m no-results-heading">No {{ heading | lower }} found</h3>
+    <p class="no-results-message">No {{ heading | lower }} information was found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/visit-details.njk
+++ b/server/views/pages/order/visit-details.njk
@@ -21,6 +21,13 @@
     {{ heading }}
   </h1>
 
-  {{ emsEventTimeline(visitDetails) }}
+  {% if visitDetails|length %}
+    {{ emsDateFilter() }}
+    <hr class="govuk-section-break govuk-section-break--m">
+    {{ emsEventTimeline(visitDetails) }}
+  {% else %}
+    <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
+    <p>There are no {{ heading | lower }} associated with this order</p>
+  {% endif %}
 
 {% endblock %}

--- a/server/views/pages/order/visit-details.njk
+++ b/server/views/pages/order/visit-details.njk
@@ -27,7 +27,7 @@
     {{ emsEventTimeline(visitDetails) }}
   {% else %}
     <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
-    <p>There are no {{ heading | lower }} associated with this order</p>
+    <p>No {{ heading | lower }} information was found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/suspensionOfVisits.njk
+++ b/server/views/pages/suspensionOfVisits.njk
@@ -22,54 +22,61 @@
     {{ heading }}
   </h1>
 
-  {{ emsDateFilter() }}
+  {% if events|length %}
 
-  <hr class="govuk-section-break govuk-section-break--m">
+    {{ emsDateFilter() }}
 
-  {% set timelineItems = [] %}
+    <hr class="govuk-section-break govuk-section-break--m">
 
-  {% for event in events %}
-    {% set timelineEntryHtml %}
-      {{
-        govukSummaryList({
-          rows: [
-            {
-              key: { text: "Suspension of visits" },
-              value: { text: event.suspensionOfVisits }
-            },
-            {
-              key: { text: "Suspension of visits requested date" },
-              value: { text: event.requestedDate }
-            },
-            {
-              key: { text: "Suspension of visits start date" },
-              value: { text: event.startDate }
-            },
-            {
-              key: { text: "Suspension of visits start time" },
-              value: { text: event.startTime }
-            },
-            {
-              key: { text: "Suspension of visits end date" },
-              value: { text: event.endDate }
-            }
-          ]
-        })
-      }}
-    {% endset %}
+    {% set timelineItems = [] %}
 
-    {% set timelineItems = (timelineItems.push({
-        label: { text: "Suspension of visits" },
-        html: timelineEntryHtml,
-        datetime: {
-          timestamp: event.timestamp,
-          type: 'shortdate'
-        }
-      }), timelineItems) %}
-  {% endfor %}
+    {% for event in events %}
+      {% set timelineEntryHtml %}
+        {{
+          govukSummaryList({
+            rows: [
+              {
+                key: { text: "Suspension of visits" },
+                value: { text: event.suspensionOfVisits }
+              },
+              {
+                key: { text: "Suspension of visits requested date" },
+                value: { text: event.requestedDate }
+              },
+              {
+                key: { text: "Suspension of visits start date" },
+                value: { text: event.startDate }
+              },
+              {
+                key: { text: "Suspension of visits start time" },
+                value: { text: event.startTime }
+              },
+              {
+                key: { text: "Suspension of visits end date" },
+                value: { text: event.endDate }
+              }
+            ]
+          })
+        }}
+      {% endset %}
 
-  {{ mojTimeline({
-    items: timelineItems
-  })}}
+      {% set timelineItems = (timelineItems.push({
+          label: { text: "Suspension of visits" },
+          html: timelineEntryHtml,
+          datetime: {
+            timestamp: event.timestamp,
+            type: 'shortdate'
+          }
+        }), timelineItems) %}
+    {% endfor %}
+
+    {{ mojTimeline({
+      items: timelineItems
+    })}}
+
+  {% else %}
+    <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
+    <p>There are no {{ heading | lower }} associated with this order</p>
+  {% endif %}
 
 {% endblock %}

--- a/server/views/pages/suspensionOfVisits.njk
+++ b/server/views/pages/suspensionOfVisits.njk
@@ -76,7 +76,7 @@
 
   {% else %}
     <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
-    <p>There are no {{ heading | lower }} associated with this order</p>
+    <p>No {{ heading | lower }} information was found for this order</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/suspensionOfVisits.njk
+++ b/server/views/pages/suspensionOfVisits.njk
@@ -75,8 +75,8 @@
     })}}
 
   {% else %}
-    <h3 class="govuk-heading-m">No {{ heading | lower }} found</h3>
-    <p>No {{ heading | lower }} information was found for this order</p>
+    <h3 class="govuk-heading-m no-results-heading">No {{ heading | lower }} found</h3>
+    <p class="no-results-message">No {{ heading | lower }} information was found for this order</p>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Adds 'no results' fallback messages to timeline pages.
These render when Athena returns no events to display in the timeline component.
![image](https://github.com/user-attachments/assets/79bf66a3-4a08-4d10-b5a7-be00cf07e229)


Also removes a period from the end of a warning message, for consistent type styling.
![image](https://github.com/user-attachments/assets/d1dd3054-90f9-4464-9895-88135fa3dd53)

