### PR TITLE
Order search: Include legacy subject ID

### DIFF
--- a/integration_tests/pages/search.ts
+++ b/integration_tests/pages/search.ts
@@ -9,9 +9,9 @@ export default class SearchPage extends Page {
 
   serviceInformationText = (): PageElement => cy.get('.service-information').children('.govuk-warning-text__text')
 
-  subjectIdField = (): PageElement => cy.get('#subject-id')
+  subjectIdField = (): PageElement => cy.get('#legacy-subject-id')
 
-  subjectIdLabel = (): PageElement => cy.get('#subject-id').siblings('label')
+  subjectIdLabel = (): PageElement => cy.get('#legacy-subject-id').siblings('label')
 
   firstNameField = (): PageElement => cy.get('#first-name')
 

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -51,8 +51,8 @@
             classes: "govuk-label--s"
           },
           classes: "govuk-!-width-two-thirds",
-          id: "subject-id",
-          name: "subjectId",
+          id: "legacy-subject-id",
+          name: "legacySubjectId",
           value: legacySubjectId.value,
           errorMessage: legacySubjectId.error
         }) }}


### PR DESCRIPTION
Include the legacy subject ID in order searches.