### PR TITLE
Fix search results table sorting

### DIFF
--- a/server/utils/tabulateOrders.ts
+++ b/server/utils/tabulateOrders.ts
@@ -42,16 +42,16 @@ const tabulateOrders = (orders: Order[]) => {
         text: order.dateOfBirth,
         attributes: {
           'data-sort-value':
-            order.dateOfBirth.split('-')[2] + order.dateOfBirth.split('-')[1] + order.dateOfBirth.split('-')[0],
+            order.dateOfBirth.split('-')[0] + order.dateOfBirth.split('-')[1] + order.dateOfBirth.split('-')[2],
         },
       },
       {
         text: order.orderStartDate,
         attributes: {
           'data-sort-value':
-            order.orderStartDate.split('-')[2] +
+            order.orderStartDate.split('-')[0] +
             order.orderStartDate.split('-')[1] +
-            order.orderStartDate.split('-')[0],
+            order.orderStartDate.split('-')[2],
         },
         classes: 'govuk-table__cell--numeric',
       },
@@ -59,7 +59,7 @@ const tabulateOrders = (orders: Order[]) => {
         text: order.orderEndDate,
         attributes: {
           'data-sort-value':
-            order.orderEndDate.split('-')[2] + order.orderEndDate.split('-')[1] + order.orderEndDate.split('-')[0],
+            order.orderEndDate.split('-')[0] + order.orderEndDate.split('-')[1] + order.orderEndDate.split('-')[2],
         },
         classes: 'govuk-table__cell--numeric',
       },


### PR DESCRIPTION
In the search results page, sorting by `date of birth`, `order start date` or `order end date` didn't place rows in the correct order.
This is because the date was processed into a string of format `DDMMYYYY`, which was used for sorting.

This change fixes date sorting by changing the format of the sorting string to `YYYYMMDD`.