### PR TITLE
Alcohol monitoring search route

### DIFF
--- a/integration_tests/e2e/searchResults.cy.ts
+++ b/integration_tests/e2e/searchResults.cy.ts
@@ -4,145 +4,151 @@ import Page from '../pages/page'
 import orders from '../../server/data/mockData/orders'
 
 context('SearchResults', () => {
-  describe('No results found view', () => {
-    const queryExecutionId = 'query-execution-id'
+  const paths = ['/search/integrity', '/search/alcohol-monitoring']
 
-    beforeEach(() => {
-      cy.task('reset')
-      cy.task('stubSignIn', { name: 'Master Tester', roles: ['ROLE_EM_DATASTORE_GENERAL_RO'] })
-      cy.task('stubDatastoreGetSearchResults', {
-        queryExecutionId: 'query-execution-id',
-        httpStatus: 200,
-        results: [],
-      })
-      cy.signIn()
-      cy.visit(`/search/orders?search_id=${queryExecutionId}`)
-    })
+  paths.forEach(path => {
+    describe(path, () => {
+      describe('No results found view', () => {
+        const queryExecutionId = 'query-execution-id'
 
-    it('is reachable', () => {
-      Page.verifyOnPage(SearchResultsPage)
-    })
+        beforeEach(() => {
+          cy.task('reset')
+          cy.task('stubSignIn', { name: 'Master Tester', roles: ['ROLE_EM_DATASTORE_GENERAL_RO'] })
+          cy.task('stubDatastoreGetSearchResults', {
+            queryExecutionId: 'query-execution-id',
+            httpStatus: 200,
+            results: [],
+          })
+          cy.signIn()
+          cy.visit(`${path}?search_id=${queryExecutionId}`)
+        })
 
-    describe('Service information banner', () => {
-      it('Service information banner renders', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.serviceInformation().should('be.visible')
-      })
+        it('is reachable', () => {
+          Page.verifyOnPage(SearchResultsPage)
+        })
 
-      it('Service information banner text is correct', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage
-          .serviceInformation()
-          .should('contain', 'This service gives you access to all order data that was held by Capita and G4S')
-      })
-    })
+        describe('Service information banner', () => {
+          it('Service information banner renders', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.serviceInformation().should('be.visible')
+          })
 
-    describe('No results message', () => {
-      it('No results heading renders', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.noResultsHeader().should('be.visible')
-      })
+          it('Service information banner text is correct', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage
+              .serviceInformation()
+              .should('contain', 'This service gives you access to all order data that was held by Capita and G4S')
+          })
+        })
 
-      it('No results heading text is correct', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.noResultsHeader().should('contain', 'No results found')
-      })
+        describe('No results message', () => {
+          it('No results heading renders', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.noResultsHeader().should('be.visible')
+          })
 
-      it('No results message renders', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.noResultsMessage().should('be.visible')
-      })
+          it('No results heading text is correct', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.noResultsHeader().should('contain', 'No results found')
+          })
 
-      it('No results message text is correct', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.noResultsMessage().should('contain', 'Sorry, no results were found for this search')
-      })
-    })
+          it('No results message renders', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.noResultsMessage().should('be.visible')
+          })
 
-    describe('Return to search page button', () => {
-      it('Return to search page button renders', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.returnToSearchButton().should('be.visible')
-      })
+          it('No results message text is correct', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.noResultsMessage().should('contain', 'Sorry, no results were found for this search')
+          })
+        })
 
-      it('Return to search page button href is correct', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.returnToSearchButton().should('have.attr', 'href', '/search')
-      })
-    })
-  })
+        describe('Return to search page button', () => {
+          it('Return to search page button renders', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.returnToSearchButton().should('be.visible')
+          })
 
-  describe('Results found view', () => {
-    const queryExecutionId = 'query-execution-id'
-
-    beforeEach(() => {
-      cy.task('reset')
-      cy.task('stubSignIn', { name: 'Master Tester', roles: ['ROLE_EM_DATASTORE_GENERAL_RO'] })
-
-      cy.task('stubDatastoreGetSearchResults', {
-        queryExecutionId: 'query-execution-id',
-        httpStatus: 200,
-        results: orders,
+          it('Return to search page button href is correct', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.returnToSearchButton().should('have.attr', 'href', '/search')
+          })
+        })
       })
 
-      cy.signIn()
-      cy.visit(`/search/orders?search_id=${queryExecutionId}`)
-    })
+      describe('Results found view', () => {
+        const queryExecutionId = 'query-execution-id'
 
-    it('is reachable', () => {
-      Page.verifyOnPage(SearchResultsPage)
-    })
+        beforeEach(() => {
+          cy.task('reset')
+          cy.task('stubSignIn', { name: 'Master Tester', roles: ['ROLE_EM_DATASTORE_GENERAL_RO'] })
 
-    describe('Service information banner', () => {
-      it('Service information banner renders', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.serviceInformation().should('be.visible')
-      })
+          cy.task('stubDatastoreGetSearchResults', {
+            queryExecutionId: 'query-execution-id',
+            httpStatus: 200,
+            results: orders,
+          })
 
-      it('Service information banner text is correct', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage
-          .serviceInformation()
-          .should('contain', 'This service gives you access to all order data that was held by Capita and G4S')
-      })
-    })
+          cy.signIn()
+          cy.visit(`${path}?search_id=${queryExecutionId}`)
+        })
 
-    describe('Search results table', () => {
-      it('The table renders', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.resultsTable().should('be.visible')
-      })
+        it('is reachable', () => {
+          Page.verifyOnPage(SearchResultsPage)
+        })
 
-      it('The subject ID column header contains the correct text', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.subjectIdHeader().should('contain', 'Legacy subject ID')
-      })
+        describe('Service information banner', () => {
+          it('Service information banner renders', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.serviceInformation().should('be.visible')
+          })
 
-      it('The name column header contains the correct text', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.nameHeader().should('contain', 'Name')
-      })
+          it('Service information banner text is correct', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage
+              .serviceInformation()
+              .should('contain', 'This service gives you access to all order data that was held by Capita and G4S')
+          })
+        })
 
-      it('The date of birth column header contains the correct text', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.dateOfBirthHeader().should('contain', 'Date of birth')
-      })
+        describe('Search results table', () => {
+          it('The table renders', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.resultsTable().should('be.visible')
+          })
 
-      it('The order start date column header contains the correct text', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.orderStartDateHeader().should('contain', 'Order start date')
-      })
+          it('The subject ID column header contains the correct text', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.subjectIdHeader().should('contain', 'Legacy subject ID')
+          })
 
-      it('The order end date column header contains the correct text', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.orderEndDateHeader().should('contain', 'Order end date')
-      })
-    })
+          it('The name column header contains the correct text', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.nameHeader().should('contain', 'Name')
+          })
 
-    describe('Pagination', () => {
-      it('The pagination component renders', () => {
-        const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
-        searchResultsPage.pagination().should('be.visible')
+          it('The date of birth column header contains the correct text', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.dateOfBirthHeader().should('contain', 'Date of birth')
+          })
+
+          it('The order start date column header contains the correct text', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.orderStartDateHeader().should('contain', 'Order start date')
+          })
+
+          it('The order end date column header contains the correct text', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.orderEndDateHeader().should('contain', 'Order end date')
+          })
+        })
+
+        describe('Pagination', () => {
+          it('The pagination component renders', () => {
+            const searchResultsPage = Page.verifyOnPage(SearchResultsPage)
+            searchResultsPage.pagination().should('be.visible')
+          })
+        })
       })
     })
   })

--- a/integration_tests/mockApis/datastore.ts
+++ b/integration_tests/mockApis/datastore.ts
@@ -20,7 +20,7 @@ type GetSearchResultsStubOptions = {
 const getSearchResults = (options: GetSearchResultsStubOptions = defaultGetSearchResultsOptions): SuperAgentRequest =>
   stubFor({
     request: {
-      method: 'GET',
+      method: 'POST',
       urlPattern: `/datastore${config.apiEndpoints.searchOrders}/${options.queryExecutionId}`,
     },
     response: {

--- a/server/controllers/searchController.test.ts
+++ b/server/controllers/searchController.test.ts
@@ -8,6 +8,7 @@ import orders from '../data/mockData/orders'
 import ordersView from '../data/mockData/ordersView'
 import { createMockRequest, createMockResponse } from '../testutils/mocks/mockExpress'
 import { ParsedSearchFormData, ParsedSearchFormDataModel } from '../models/form-data/searchOrder'
+import { ErrorMessage, TextField } from '../models/utils'
 
 jest.mock('../services/auditService')
 jest.mock('../services/datastoreSearchService')
@@ -86,6 +87,7 @@ describe('SearchController', () => {
       ]
 
       req.session.formData = {
+        searchType: 'integrity',
         firstName: 'John123',
         lastName: 'Doe',
         alias: 'JD',
@@ -95,6 +97,10 @@ describe('SearchController', () => {
       }
 
       const expectedViewModel = {
+        searchType: {
+          value: 'integrity',
+        },
+        legacySubjectId: undefined as TextField | undefined,
         firstName: {
           value: 'John123',
           error: {
@@ -117,6 +123,7 @@ describe('SearchController', () => {
             text: 'Invalid date format',
           },
         },
+        emptyFormError: undefined as ErrorMessage | undefined,
       }
 
       await searchController.searchPage(req, res, jest.fn())
@@ -197,6 +204,7 @@ describe('SearchController', () => {
       ]
 
       req.body = {
+        searchType: 'integrity',
         firstName: '',
         lastName: '',
         alias: '',
@@ -206,6 +214,7 @@ describe('SearchController', () => {
       }
 
       const parsedFormData = {
+        searchType: 'integrity',
         firstName: '',
         lastName: '',
         alias: '',
@@ -228,10 +237,20 @@ describe('SearchController', () => {
       datastoreSearchService.validateInput = jest.fn().mockReturnValueOnce([])
       datastoreSearchService.submitSearchQuery = jest.fn().mockResolvedValue(queryExecutionResponse)
 
+      req.body = {
+        searchType: 'integrity',
+        firstName: '',
+        lastName: '',
+        alias: '',
+        'dob-day': '',
+        'dob-month': '',
+        'dob-year': '',
+      }
+
       await searchController.submitSearchQuery(req, res, next)
 
       expect(ParsedSearchFormDataModel.parse).toHaveBeenCalledWith(req.body)
-      expect(res.redirect).toHaveBeenCalledWith(`search/orders?search_id=${queryExecutionId}`)
+      expect(res.redirect).toHaveBeenCalledWith(`search/integrity?search_id=${queryExecutionId}`)
     })
   })
 

--- a/server/controllers/searchController.ts
+++ b/server/controllers/searchController.ts
@@ -61,8 +61,9 @@ export default class SearchController {
       req.session.validationErrors = undefined
       req.session.formData = undefined
 
-      // Redirect to results page
-      res.redirect(`search/orders?search_id=${encodeURIComponent(queryExecutionResponse.queryExecutionId)}`)
+      res.redirect(
+        `search/${req.body.searchType}?search_id=${encodeURIComponent(queryExecutionResponse.queryExecutionId)}`,
+      )
     }
   }
 

--- a/server/data/datastoreClient.test.ts
+++ b/server/data/datastoreClient.test.ts
@@ -88,7 +88,7 @@ describe('EM Datastore Search Client', () => {
     const endpoint = `${config.apiEndpoints.searchOrders}/${queryExecutionId}`
 
     it('should return a list of orders from the API', async () => {
-      fakeClient.get(endpoint).matchHeader('Authorization', `Bearer ${token}`).reply(200, orders)
+      fakeClient.post(endpoint).matchHeader('Authorization', `Bearer ${token}`).reply(200, orders)
 
       const expected = orders
 
@@ -98,7 +98,7 @@ describe('EM Datastore Search Client', () => {
     })
 
     it('should handle 401 Unauthorized when the user token is invalid', async () => {
-      fakeClient.get(endpoint).matchHeader('Authorization', `Bearer ${token}`).reply(401)
+      fakeClient.post(endpoint).matchHeader('Authorization', `Bearer ${token}`).reply(401)
 
       await expect(datastoreClient.getSearchResults(resultsRequest)).rejects.toThrow('Unauthorized')
     })

--- a/server/data/datastoreClient.ts
+++ b/server/data/datastoreClient.ts
@@ -43,8 +43,7 @@ export default class DatastoreClient {
 
   async getSearchResults(request: SearchResultsRequest): Promise<Order[]> {
     const { queryExecutionId } = request
-
-    const orders: Order[] = await this.restClient.get({
+    const orders: Order[] = await this.restClient.post({
       path: `${config.apiEndpoints.searchOrders}/${queryExecutionId}`,
     })
 

--- a/server/data/mockData/orders.ts
+++ b/server/data/mockData/orders.ts
@@ -4,7 +4,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 1000000,
-    name: 'Amy Smith',
+    firstName: 'Amy',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -17,7 +18,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 2000000,
-    name: 'Bill Smith',
+    firstName: 'Bill',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -30,7 +32,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 3000000,
-    name: 'Claire Smith',
+    firstName: 'Claire',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -43,7 +46,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 8000000,
-    name: 'Daniel Smith',
+    firstName: 'Daniel',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -56,7 +60,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 30000,
-    name: 'Emma Smith',
+    firstName: 'Emma',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -69,7 +74,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 4000000,
-    name: 'Fred Smith',
+    firstName: 'Fred',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -82,7 +88,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 30000,
-    name: 'Geoff Smith',
+    firstName: 'Geoff',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -95,7 +102,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 4000000,
-    name: 'Hortense Smith',
+    firstName: 'Hortense',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -108,7 +116,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 30000,
-    name: 'Isaac Smith',
+    firstName: 'Isaac',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -121,7 +130,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 4000000,
-    name: 'Jessica Smith',
+    firstName: 'Jessica',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -134,7 +144,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 30000,
-    name: 'Ken Smith',
+    firstName: 'Ken',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -147,7 +158,8 @@ const orders: Order[] = [
   {
     dataType: 'am',
     legacySubjectId: 4000000,
-    name: 'Lucille Smith',
+    firstName: 'Lucille',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',

--- a/server/data/mockData/ordersView.ts
+++ b/server/data/mockData/ordersView.ts
@@ -4,7 +4,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 1000000,
-    name: 'Amy Smith',
+    firstName: 'Amy',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -21,7 +22,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 2000000,
-    name: 'Bill Smith',
+    firstName: 'Bill',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -38,7 +40,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 3000000,
-    name: 'Claire Smith',
+    firstName: 'Claire',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -55,7 +58,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 8000000,
-    name: 'Daniel Smith',
+    firstName: 'Daniel',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -72,7 +76,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 30000,
-    name: 'Emma Smith',
+    firstName: 'Emma',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -89,7 +94,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 4000000,
-    name: 'Fred Smith',
+    firstName: 'Fred',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -106,7 +112,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 30000,
-    name: 'Geoff Smith',
+    firstName: 'Geoff',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -123,7 +130,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 4000000,
-    name: 'Hortense Smith',
+    firstName: 'Hortense',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -140,7 +148,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 30000,
-    name: 'Isaac Smith',
+    firstName: 'Isaac',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -157,7 +166,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 4000000,
-    name: 'Jessica Smith',
+    firstName: 'Jessica',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -174,7 +184,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 30000,
-    name: 'Ken Smith',
+    firstName: 'Ken',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',
@@ -191,7 +202,8 @@ const ordersView: OrdersViewModel = [
   {
     dataType: 'am',
     legacySubjectId: 4000000,
-    name: 'Lucille Smith',
+    firstName: 'Lucille',
+    lastName: 'Smith',
     addressLine1: 'First line of address',
     addressLine2: 'Second line of address',
     addressLine3: 'Third line of address',

--- a/server/interfaces/order.ts
+++ b/server/interfaces/order.ts
@@ -1,7 +1,8 @@
 export interface Order {
   dataType: string
   legacySubjectId?: number
-  name?: string
+  firstName?: string
+  lastName?: string
   addressLine1?: string
   addressLine2?: string
   addressLine3?: string

--- a/server/models/view-models/searchResults.ts
+++ b/server/models/view-models/searchResults.ts
@@ -3,7 +3,8 @@ import { Order } from '../../interfaces/order'
 export type OrdersViewModel = {
   dataType: string
   legacySubjectId?: number
-  name?: string
+  firstName?: string
+  lastName?: string
   addressLine1?: string
   addressLine2?: string
   addressLine3?: string

--- a/server/routes/searchRouter.ts
+++ b/server/routes/searchRouter.ts
@@ -13,7 +13,8 @@ export default function searchRouter({ auditService, datastoreSearchService }: S
 
   get('/', searchController.searchPage)
   post('/', searchController.submitSearchQuery)
-  get('/orders', searchController.searchResultsPage)
+  get('/integrity', searchController.searchResultsPage)
+  get('/alcohol-monitoring', searchController.searchResultsPage)
 
   return router
 }

--- a/server/services/datastoreSearchService.ts
+++ b/server/services/datastoreSearchService.ts
@@ -22,7 +22,8 @@ export default class DatastoreSearchService {
   }
 
   isEmptySearch(searchData: ParsedSearchFormData): boolean {
-    return Object.values(searchData).every(value => value === '' || value === undefined)
+    const { searchType, ...mandatoryFields } = searchData
+    return Object.values(mandatoryFields).every(value => value === '' || value === undefined)
   }
 
   validateInput(input: SearchFormInput): ValidationResult {

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -19,31 +19,35 @@
         {% endif %}
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        {# TODO: Not enabled until we have alcohol monitoring #}
-        {# {{ govukRadios({
-          classes: "govuk-radios--small",
-          name: "searchType",
-          fieldset: {
-            legend: {
-              text: "What data are you searching for?",
-              isPageHeading: false,
-              classes: "govuk-fieldset__legend--m"
-            }
-          },
-          items: [
-            {
-              value: "integrity",
-              text: "Integrity data only"
+        
+        {# TODO: Remove environment flag when AM is ready for deployment to preprod & prod #}
+        {% if (environmentName == 'dev') %}
+          {{ govukRadios({
+            classes: "govuk-radios--small",
+            name: "searchType",
+            fieldset: {
+              legend: {
+                text: "What data are you searching for?",
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+              }
             },
-            {
-              value: "am",
-              text: "Alcohol monitoring data only"
+            items: [
+              {
+                value: "integrity",
+                text: "Integrity data only",
+                checked: true
+              },
+              {
+                value: "am",
+                text: "Alcohol monitoring data only"
+              }
+            ],
+            errorMessage: {
+              text: "Select the type of data to search for"
             }
-          ],
-          errorMessage: {
-            text: "Select the type of data to search for"
-          }
-        }) }} #}
+          }) }}
+        {% endif %}
 
         {{ govukInput({
           label: {

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -42,10 +42,7 @@
                 value: "alcohol-monitoring",
                 text: "Alcohol monitoring data only"
               }
-            ],
-            errorMessage: {
-              text: "Select the type of data to search for"
-            }
+            ]
           }) }}
         {% endif %}
 

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -39,7 +39,7 @@
                 checked: true
               },
               {
-                value: "am",
+                value: "alcohol-monitoring",
                 text: "Alcohol monitoring data only"
               }
             ],

--- a/server/views/pages/searchResults.njk
+++ b/server/views/pages/searchResults.njk
@@ -25,8 +25,8 @@
   {% endset %} 
 
   {% set nameHtml %}
-    {% if (order.name) %}
-      <p>{{ order.name }}</p>
+    {% if (order.firstName or order.lastName) %}
+      <p>{{ order.firstName | upper }} {{ order.lastName | upper }} </p>
       {% if (order.alias) %}
         <p>Alias: {{ order.alias }}</p>
       {% endif %}


### PR DESCRIPTION
- Set up the path for searching alcohol monitoring orders
- Configure the search result model to receive separate first name & last name properties, rather than a concatenated full name property.

_NB: Currently AM orders cannot be searched because column names in the Athena table `am_order_details` do not match the equivalent column's names in the integrity `order_details` table. I've contacted data colleagues to check whether our preference is to align column names in the two Athena tables, or separate the AM & integrity search paths / query generators. Either way, it's a backend concern._