### PR TITLE
Path improvements

### DIFF
--- a/integration_tests/e2e/integrity/curfew-timetable.cy.ts
+++ b/integration_tests/e2e/integrity/curfew-timetable.cy.ts
@@ -11,7 +11,7 @@ context('Crufew Timetable', () => {
   })
 
   it('Should display the user name visible in header', () => {
-    cy.task('stubDatastoreGetCurfewTimetable', {
+    cy.task('stubDatastoreGetServiceDetails', {
       httpStatus: 200,
       legacySubjectId,
       body: [],
@@ -22,7 +22,7 @@ context('Crufew Timetable', () => {
   })
 
   it('Should display the phase banner in header', () => {
-    cy.task('stubDatastoreGetCurfewTimetable', {
+    cy.task('stubDatastoreGetServiceDetails', {
       httpStatus: 200,
       legacySubjectId,
       body: [],
@@ -33,7 +33,7 @@ context('Crufew Timetable', () => {
   })
 
   it('Should display the back link', () => {
-    cy.task('stubDatastoreGetCurfewTimetable', {
+    cy.task('stubDatastoreGetServiceDetails', {
       httpStatus: 200,
       legacySubjectId,
       body: [],
@@ -44,7 +44,7 @@ context('Crufew Timetable', () => {
   })
 
   it('Should be accessible', () => {
-    cy.task('stubDatastoreGetCurfewTimetable', {
+    cy.task('stubDatastoreGetServiceDetails', {
       httpStatus: 200,
       legacySubjectId,
       body: [],
@@ -56,19 +56,19 @@ context('Crufew Timetable', () => {
 
   describe('No results message', () => {
     it('Renders when no timetable entries have been found', () => {
-      cy.task('stubDatastoreGetCurfewTimetable', {
+      cy.task('stubDatastoreGetServiceDetails', {
         httpStatus: 200,
         legacySubjectId,
         body: [],
       })
 
-      const curfewTimetablePage = Page.visit(ServiceDetailsPage, { legacySubjectId })
-      curfewTimetablePage.noResultsHeading.should('be.visible')
-      curfewTimetablePage.noResultsMessage.should('be.visible')
+      const serviceDetailsPage = Page.visit(ServiceDetailsPage, { legacySubjectId })
+      serviceDetailsPage.noResultsHeading.should('be.visible')
+      serviceDetailsPage.noResultsMessage.should('be.visible')
     })
 
     it('Does not render when a timetable entry has been found', () => {
-      cy.task('stubDatastoreGetCurfewTimetable', {
+      cy.task('stubDatastoreGetServiceDetails', {
         httpStatus: 200,
         legacySubjectId,
         body: [
@@ -94,26 +94,26 @@ context('Crufew Timetable', () => {
         ],
       })
 
-      const curfewTimetablePage = Page.visit(ServiceDetailsPage, { legacySubjectId })
-      curfewTimetablePage.noResultsHeading.should('not.exist')
-      curfewTimetablePage.noResultsMessage.should('not.exist')
+      const serviceDetailsPage = Page.visit(ServiceDetailsPage, { legacySubjectId })
+      serviceDetailsPage.noResultsHeading.should('not.exist')
+      serviceDetailsPage.noResultsMessage.should('not.exist')
     })
   })
 
   describe('Timetables', () => {
     it('Does not render when no timetable entries have been found', () => {
-      cy.task('stubDatastoreGetCurfewTimetable', {
+      cy.task('stubDatastoreGetServiceDetails', {
         httpStatus: 200,
         legacySubjectId,
         body: [],
       })
 
-      const curfewTimetablePage = Page.visit(ServiceDetailsPage, { legacySubjectId })
-      curfewTimetablePage.curfewTimetable.should('not.exist')
+      const serviceDetailsPage = Page.visit(ServiceDetailsPage, { legacySubjectId })
+      serviceDetailsPage.serviceDetails.should('not.exist')
     })
 
     it('Renders when one timetable entry has been found', () => {
-      cy.task('stubDatastoreGetCurfewTimetable', {
+      cy.task('stubDatastoreGetServiceDetails', {
         httpStatus: 200,
         legacySubjectId,
         body: [
@@ -139,14 +139,14 @@ context('Crufew Timetable', () => {
         ],
       })
 
-      const curfewTimetablePage = Page.visit(ServiceDetailsPage, { legacySubjectId })
-      curfewTimetablePage.curfewTimetable.should('be.visible')
-      curfewTimetablePage.curfewTimetableItems.should('have.length', 1)
-      curfewTimetablePage.getCurfewTimetableItem(0).contains('Service ID 321')
+      const serviceDetailsPage = Page.visit(ServiceDetailsPage, { legacySubjectId })
+      serviceDetailsPage.serviceDetails.should('be.visible')
+      serviceDetailsPage.serviceDetails.should('have.length', 1)
+      serviceDetailsPage.getServiceDetailsItem(0).contains('Service ID 321')
     })
 
     it('Renders when multiple timetable entries have been found', () => {
-      cy.task('stubDatastoreGetCurfewTimetable', {
+      cy.task('stubDatastoreGetServiceDetails', {
         httpStatus: 200,
         legacySubjectId,
         body: [
@@ -191,11 +191,11 @@ context('Crufew Timetable', () => {
         ],
       })
 
-      const curfewTimetablePage = Page.visit(ServiceDetailsPage, { legacySubjectId })
-      curfewTimetablePage.curfewTimetable.should('be.visible')
-      curfewTimetablePage.curfewTimetableItems.should('have.length', 2)
-      curfewTimetablePage.getCurfewTimetableItem(0).contains('Service ID 321')
-      curfewTimetablePage.getCurfewTimetableItem(1).contains('Service ID 654')
+      const serviceDetailsPage = Page.visit(ServiceDetailsPage, { legacySubjectId })
+      serviceDetailsPage.serviceDetails.should('be.visible')
+      serviceDetailsPage.serviceDetailsItems.should('have.length', 2)
+      serviceDetailsPage.getServiceDetailsItem(0).contains('Service ID 321')
+      serviceDetailsPage.getServiceDetailsItem(1).contains('Service ID 654')
     })
   })
 })

--- a/integration_tests/e2e/integrity/equipment-details.cy.ts
+++ b/integration_tests/e2e/integrity/equipment-details.cy.ts
@@ -75,7 +75,6 @@ context('Equipment Details', () => {
         body: [
           {
             legacySubjectId: 123,
-            legacyOrderId: 321,
             pid: {
               id: '123456',
               equipmentCategoryDescription: 'TEST_PID_DESCRIPTION',
@@ -117,7 +116,6 @@ context('Equipment Details', () => {
         body: [
           {
             legacySubjectId: 123,
-            legacyOrderId: 321,
             pid: {
               id: '123456',
               equipmentCategoryDescription: 'TEST_PID_DESCRIPTION',
@@ -148,7 +146,6 @@ context('Equipment Details', () => {
         body: [
           {
             legacySubjectId: 123,
-            legacyOrderId: 321,
             pid: {
               id: '123456',
               equipmentCategoryDescription: 'TEST_PID_DESCRIPTION',
@@ -164,7 +161,6 @@ context('Equipment Details', () => {
           },
           {
             legacySubjectId: 456,
-            legacyOrderId: 654,
             pid: {
               id: '012938',
               equipmentCategoryDescription: 'TEST_PID_DESCRIPTION',
@@ -197,7 +193,6 @@ context('Equipment Details', () => {
         body: [
           {
             legacySubjectId: 123,
-            legacyOrderId: 321,
             hmu: {
               id: '098765',
               equipmentCategoryDescription: 'TEST_HMU_DESCRIPTION',
@@ -222,7 +217,6 @@ context('Equipment Details', () => {
         body: [
           {
             legacySubjectId: 123,
-            legacyOrderId: 321,
             pid: {
               id: '012938',
               equipmentCategoryDescription: 'TEST_PID_DESCRIPTION',

--- a/integration_tests/e2e/integrity/event-history.cy.ts
+++ b/integration_tests/e2e/integrity/event-history.cy.ts
@@ -13,7 +13,6 @@ context('Event history', () => {
       legacySubjectId,
       body: [
         {
-          legacyOrderId: legacySubjectId,
           legacySubjectId,
           type: 'monitoring',
           dateTime: '2022-02-02T01:03:03',
@@ -29,7 +28,6 @@ context('Event history', () => {
       legacySubjectId,
       body: [
         {
-          legacyOrderId: legacySubjectId,
           legacySubjectId,
           type: 'incident',
           dateTime: '2022-02-02T01:06:06',
@@ -45,7 +43,6 @@ context('Event history', () => {
       legacySubjectId,
       body: [
         {
-          legacyOrderId: legacySubjectId,
           legacySubjectId,
           type: 'contact',
           dateTime: '2022-02-03T01:09:09',
@@ -67,7 +64,6 @@ context('Event history', () => {
       legacySubjectId,
       body: [
         {
-          legacyOrderId: legacySubjectId,
           legacySubjectId,
           type: 'violation',
           dateTime: '2022-02-03T01:12:12',

--- a/integration_tests/e2e/integrity/summary.cy.ts
+++ b/integration_tests/e2e/integrity/summary.cy.ts
@@ -204,7 +204,7 @@ context('Order Information', () => {
     })
 
     it('Contains services button and navigates to expected page', () => {
-      cy.task('stubDatastoreGetCurfewTimetable', {
+      cy.task('stubDatastoreGetServiceDetails', {
         httpStatus: 200,
         legacySubjectId,
         body: [],

--- a/integration_tests/e2e/integrity/visit-details.cy.ts
+++ b/integration_tests/e2e/integrity/visit-details.cy.ts
@@ -62,7 +62,6 @@ context('Visit details', () => {
         legacySubjectId,
         body: [
           {
-            legacyOrderId: 123,
             legacySubjectId: 321,
             address: {
               addressLine1: 'address line 1',
@@ -92,7 +91,6 @@ context('Visit details', () => {
         legacySubjectId,
         body: [
           {
-            legacyOrderId: 123,
             legacySubjectId: 321,
             address: {
               addressLine1: 'address line 1',
@@ -129,7 +127,6 @@ context('Visit details', () => {
         legacySubjectId,
         body: [
           {
-            legacyOrderId: 123,
             legacySubjectId: 321,
             address: {
               addressLine1: 'address line 1',
@@ -145,7 +142,6 @@ context('Visit details', () => {
             visitOutcome: 'TEST_OUTCOME',
           },
           {
-            legacyOrderId: 123,
             legacySubjectId: 321,
             address: {
               addressLine1: 'address line 5',

--- a/integration_tests/mockApis/datastore.ts
+++ b/integration_tests/mockApis/datastore.ts
@@ -215,11 +215,11 @@ type GetBasicStubOptions = {
   body?: unknown[]
 }
 
-const getCurfewTimetable = (options: GetBasicStubOptions = defaultBasicStubOptions): SuperAgentRequest =>
+const getServiceDetails = (options: GetBasicStubOptions = defaultBasicStubOptions): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'GET',
-      url: `/datastore/integrity/orders/${options.legacySubjectId}/curfew-timetable`,
+      url: `/datastore/integrity/orders/${options.legacySubjectId}/service-details`,
     },
     response: {
       status: options.httpStatus,
@@ -314,7 +314,7 @@ export default {
   stubDatastoreGetContactEvents: getContactEvents,
   stubDatastoreGetOrderSummary: getOrderSummary,
   stubDatastoreGetSuspensionOfVisits: getSuspensionOfVisits,
-  stubDatastoreGetCurfewTimetable: getCurfewTimetable,
+  stubDatastoreGetServiceDetails: getServiceDetails,
   stubDatastoreGetEquipmentDetails: getEquipmentDetails,
   stubDatastoreGetViolationEvents: getViolationEvents,
   stubDatastoreGetVisitDetails: getVisitDetails,

--- a/integration_tests/pages/integrity/serviceDetails.ts
+++ b/integration_tests/pages/integrity/serviceDetails.ts
@@ -7,15 +7,15 @@ export default class ServiceDetailsPage extends AppPage {
     super('Services', paths.INTEGRITY_ORDER.SERVICE_DETAILS)
   }
 
-  get curfewTimetable(): PageElement {
+  get serviceDetails(): PageElement {
     return cy.get('.moj-timeline')
   }
 
-  get curfewTimetableItems(): PageElement {
+  get serviceDetailsItems(): PageElement {
     return cy.get('.moj-timeline').find('.moj-timeline__item')
   }
 
-  getCurfewTimetableItem(index: number): PageElement {
+  getServiceDetailsItem(index: number): PageElement {
     return cy.get('.moj-timeline').find('.moj-timeline__item').eq(index)
   }
 

--- a/server/controllers/alcoholMonitoring/equipmentDetailsController.test.ts
+++ b/server/controllers/alcoholMonitoring/equipmentDetailsController.test.ts
@@ -65,14 +65,12 @@ describe('EquipmentDetailsController', () => {
       equipmentDetails: [
         {
           legacySubjectId: testOrderId,
-          legacyOrderId: testOrderId,
           isoDateTime: undefined,
           dateTime: null,
           date: undefined,
           eventType: 'am-equipment-details',
           properties: {
             legacySubjectId: testOrderId,
-            legacyOrderId: testOrderId,
           },
         } as AlcoholMonitoringTimelineEventModel,
       ],
@@ -82,7 +80,6 @@ describe('EquipmentDetailsController', () => {
     const expectedResponse = [
       {
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
       },
     ]
 

--- a/server/controllers/alcoholMonitoring/eventHistoryController.test.ts
+++ b/server/controllers/alcoholMonitoring/eventHistoryController.test.ts
@@ -108,7 +108,6 @@ describe('AlcoholMonitoringEventHistoryController', () => {
     alcoholMonitoringEventHistoryService.getEventHistory = jest.fn().mockResolvedValue([
       AlcoholMonitoringViolationEventModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         type: eventType,
         dateTime: eventDateTime,
         details,
@@ -154,7 +153,6 @@ describe('AlcoholMonitoringEventHistoryController', () => {
     alcoholMonitoringEventHistoryService.getEventHistory = jest.fn().mockResolvedValue([
       AlcoholMonitoringIncidentEventModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         type: eventType,
         dateTime: eventDateTime,
         details,
@@ -202,7 +200,6 @@ describe('AlcoholMonitoringEventHistoryController', () => {
     alcoholMonitoringEventHistoryService.getEventHistory = jest.fn().mockResolvedValue([
       AlcoholMonitoringContactEventModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         type: eventType,
         dateTime: eventDateTime,
         details,

--- a/server/controllers/alcoholMonitoring/visitDetailsController.test.ts
+++ b/server/controllers/alcoholMonitoring/visitDetailsController.test.ts
@@ -66,7 +66,6 @@ describe('AlcoholMonitoringVisitDetailsController', () => {
 
     const visitDetails = AlcoholMonitoringVisitDetailsModel.parse({
       legacySubjectId: testOrderId,
-      legacyOrderId: testOrderId,
       visitId: '300',
       visitType: 'visit type',
       visitAttempt: 'attempt 1',

--- a/server/controllers/integrity/equipmentDetailsController.test.ts
+++ b/server/controllers/integrity/equipmentDetailsController.test.ts
@@ -81,7 +81,6 @@ describe('EquipmentDetailsController', () => {
           eventType: 'equipment-details',
           properties: {
             legacySubjectId: testOrderId,
-            legacyOrderId: testOrderId,
             pid: {
               id: 'pid_id',
               equipmentCategoryDescription: 'pid category',
@@ -103,7 +102,6 @@ describe('EquipmentDetailsController', () => {
     emDatastoreEquipmentDetailsService.getEquipmentDetails = jest.fn().mockResolvedValue([
       IntegrityEquipmentDetailsModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         pid: {
           id: 'pid_id',
           equipmentCategoryDescription: 'pid category',

--- a/server/controllers/integrity/eventHistoryController.test.ts
+++ b/server/controllers/integrity/eventHistoryController.test.ts
@@ -78,7 +78,6 @@ describe('IntegrityEventHistoryController', () => {
     integrityEventHistoryService.getEventHistory = jest.fn().mockResolvedValue([
       IntegrityMonitoringEventModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         type: eventType,
         dateTime: eventDateTime,
         details: {},
@@ -112,7 +111,6 @@ describe('IntegrityEventHistoryController', () => {
     integrityEventHistoryService.getEventHistory = jest.fn().mockResolvedValue([
       IntegrityViolationEventModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         type: eventType,
         dateTime: eventDateTime,
         details: {},
@@ -146,7 +144,6 @@ describe('IntegrityEventHistoryController', () => {
     integrityEventHistoryService.getEventHistory = jest.fn().mockResolvedValue([
       IntegrityIncidentEventModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         type: eventType,
         dateTime: eventDateTime,
         details: {},
@@ -188,7 +185,6 @@ describe('IntegrityEventHistoryController', () => {
     integrityEventHistoryService.getEventHistory = jest.fn().mockResolvedValue([
       IntegrityContactEventModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         type: eventType,
         dateTime: eventDateTime,
         details: {

--- a/server/controllers/integrity/visitDetailsController.test.ts
+++ b/server/controllers/integrity/visitDetailsController.test.ts
@@ -62,7 +62,6 @@ describe('IntegrityVisitDetailsController', () => {
           eventType: 'visit-details',
           properties: {
             legacySubjectId: testOrderId,
-            legacyOrderId: testOrderId,
             address: {
               addressLine1: 'address line 1',
               addressLine2: 'address line 2',
@@ -84,7 +83,6 @@ describe('IntegrityVisitDetailsController', () => {
     emDatastoreVisitDetailsService.getVisitDetails = jest.fn().mockResolvedValue([
       IntegrityVisitDetailsModel.parse({
         legacySubjectId: testOrderId,
-        legacyOrderId: testOrderId,
         address: {
           addressLine1: 'address line 1',
           addressLine2: 'address line 2',

--- a/server/data/emDatastoreApiClient.test.ts
+++ b/server/data/emDatastoreApiClient.test.ts
@@ -750,7 +750,7 @@ describe('EM Datastore API Client', () => {
         },
       ] as IntegrityServiceDetail[]
 
-      fakeClient.get(`/integrity/orders/${orderInfo.legacySubjectId}/curfew-timetable`).reply(200, expectedResult)
+      fakeClient.get(`/integrity/orders/${orderInfo.legacySubjectId}/service-details`).reply(200, expectedResult)
 
       const result = await emDatastoreApiClient.getIntegrityServiceDetails(orderInfo)
 
@@ -760,7 +760,7 @@ describe('EM Datastore API Client', () => {
     it('should fetch an empty list of service details', async () => {
       const expectedResult = [] as IntegrityServiceDetail[]
 
-      fakeClient.get(`/integrity/orders/${orderInfo.legacySubjectId}/curfew-timetable`).reply(200, expectedResult)
+      fakeClient.get(`/integrity/orders/${orderInfo.legacySubjectId}/service-details`).reply(200, expectedResult)
 
       const result = await emDatastoreApiClient.getIntegrityServiceDetails(orderInfo)
 
@@ -775,7 +775,7 @@ describe('EM Datastore API Client', () => {
       }
 
       nock(config.apis.emDatastoreApi.url)
-        .get(`/integrity/orders/${orderInfoWithNullToken.legacySubjectId}/curfew-timetable`)
+        .get(`/integrity/orders/${orderInfoWithNullToken.legacySubjectId}/service-details`)
         .reply(401)
 
       // Expect the method call to throw due to unauthorized access

--- a/server/data/emDatastoreApiClient.test.ts
+++ b/server/data/emDatastoreApiClient.test.ts
@@ -542,7 +542,6 @@ describe('EM Datastore API Client', () => {
       const expectedResult = [
         {
           legacySubjectId: 123,
-          legacyOrderId: 321,
         },
       ]
 
@@ -586,7 +585,6 @@ describe('EM Datastore API Client', () => {
       const expectedResult: AlcoholMonitoringEquipmentDetail[] = [
         {
           legacySubjectId: '123',
-          legacyOrderId: '321',
         },
       ]
 
@@ -622,7 +620,6 @@ describe('EM Datastore API Client', () => {
       const expectedResult = [
         {
           legacySubjectId: 123,
-          legacyOrderId: 321,
           address: {
             addressLine1: 'address line 1',
             addressLine2: 'address line 2',
@@ -678,7 +675,6 @@ describe('EM Datastore API Client', () => {
       const expectedResult = [
         {
           legacySubjectId: '123',
-          legacyOrderId: '',
           visitId: '300',
           visitType: 'visit type',
           visitAttempt: 'attempt 1',
@@ -794,7 +790,6 @@ describe('EM Datastore API Client', () => {
       const expectedResult: AlcoholMonitoringServiceDetail[] = [
         {
           legacySubjectId: '123',
-          legacyOrderId: '321',
         },
       ]
 
@@ -809,15 +804,12 @@ describe('EM Datastore API Client', () => {
       const expectedResult: AlcoholMonitoringServiceDetail[] = [
         {
           legacySubjectId: '123',
-          legacyOrderId: '321',
         },
         {
           legacySubjectId: '456',
-          legacyOrderId: '654',
         },
         {
           legacySubjectId: '789',
-          legacyOrderId: '987',
         },
       ]
 

--- a/server/data/emDatastoreApiClient.ts
+++ b/server/data/emDatastoreApiClient.ts
@@ -172,7 +172,7 @@ export default class EmDatastoreApiClient {
   async getIntegrityServiceDetails(input: OrderRequest): Promise<IntegrityServiceDetail[]> {
     const { legacySubjectId } = input
     return this.restClient.get<IntegrityServiceDetail[]>({
-      path: `/integrity/orders/${legacySubjectId}/curfew-timetable`,
+      path: `/integrity/orders/${legacySubjectId}/service-details`,
     })
   }
 

--- a/server/models/alcoholMonitoring/contactEvents.ts
+++ b/server/models/alcoholMonitoring/contactEvents.ts
@@ -15,7 +15,6 @@ export const AlcoholMonitoringContactEventDetailsModel = z.object({
 })
 
 export const AlcoholMonitoringContactEventModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   type: z.string(),
   dateTime: z.string(),

--- a/server/models/alcoholMonitoring/equipmentDetails.ts
+++ b/server/models/alcoholMonitoring/equipmentDetails.ts
@@ -1,7 +1,6 @@
 import z from 'zod'
 
 export const AlcoholMonitoringEquipmentDetailModel = z.object({
-  legacyOrderId: z.string(),
   legacySubjectId: z.string(),
   deviceType: z.string().nullable(),
   deviceSerialNumber: z.string().nullable(),

--- a/server/models/alcoholMonitoring/incidentEvents.ts
+++ b/server/models/alcoholMonitoring/incidentEvents.ts
@@ -13,7 +13,6 @@ export const AlcoholMonitoringIncidentEventDetailsModel = z.object({
 })
 
 export const AlcoholMonitoringIncidentEventModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   type: z.string(),
   dateTime: z.string(),

--- a/server/models/alcoholMonitoring/serviceDetail.ts
+++ b/server/models/alcoholMonitoring/serviceDetail.ts
@@ -2,7 +2,6 @@ import z from 'zod'
 
 export const AlcoholMonitoringServiceDetailModel = z.object({
   legacySubjectId: z.string(),
-  legacyOrderId: z.string(),
   serviceStartDate: z.string().nullable(),
   serviceEndDate: z.string().nullable(),
   serviceAddress: z.string().nullable(),

--- a/server/models/alcoholMonitoring/violationEvents.ts
+++ b/server/models/alcoholMonitoring/violationEvents.ts
@@ -16,7 +16,6 @@ export const AlcoholMonitoringViolationEventDetailsModel = z.object({
 })
 
 export const AlcoholMonitoringViolationEventModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   type: z.string(),
   dateTime: z.string(),

--- a/server/models/alcoholMonitoring/visitDetails.ts
+++ b/server/models/alcoholMonitoring/visitDetails.ts
@@ -1,7 +1,6 @@
 import z from 'zod'
 
 export const AlcoholMonitoringVisitDetailsModel = z.object({
-  legacyOrderId: z.string(),
   legacySubjectId: z.string(),
   visitId: z.string().nullable(),
   visitType: z.string().nullable(),

--- a/server/models/integrity/contactEvents.ts
+++ b/server/models/integrity/contactEvents.ts
@@ -11,7 +11,6 @@ export const IntegrityContactEventDetailsModel = z.object({
 })
 
 export const IntegrityContactEventModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   type: z.string(),
   dateTime: z.string(),

--- a/server/models/integrity/equipmentDetails.ts
+++ b/server/models/integrity/equipmentDetails.ts
@@ -8,7 +8,6 @@ export const IntegrityEquipmentDetailModel = z.object({
 })
 
 export const IntegrityEquipmentDetailsModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   pid: IntegrityEquipmentDetailModel.optional(),
   hmu: IntegrityEquipmentDetailModel.optional(),

--- a/server/models/integrity/incidentEvents.ts
+++ b/server/models/integrity/incidentEvents.ts
@@ -5,7 +5,6 @@ export const IntegrityIncidentEventDetailsModel = z.object({
 })
 
 export const IntegrityIncidentEventModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   type: z.string(),
   dateTime: z.string(),

--- a/server/models/integrity/monitoringEvents.ts
+++ b/server/models/integrity/monitoringEvents.ts
@@ -6,7 +6,6 @@ export const IntegrityMonitoringEventDetailsModel = z.object({
 })
 
 export const IntegrityMonitoringEventModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   type: z.string(),
   dateTime: z.string(),

--- a/server/models/integrity/violationEvents.ts
+++ b/server/models/integrity/violationEvents.ts
@@ -21,7 +21,6 @@ export const IntegrityViolationEventDetailsModel = z.object({
 })
 
 export const IntegrityViolationEventModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   type: z.string(),
   dateTime: z.string(),

--- a/server/models/integrity/visitDetails.ts
+++ b/server/models/integrity/visitDetails.ts
@@ -9,7 +9,6 @@ export const IntegrityVisitAddressDetailsModel = z.object({
 })
 
 export const IntegrityVisitDetailsModel = z.object({
-  legacyOrderId: z.number(),
   legacySubjectId: z.number(),
   address: IntegrityVisitAddressDetailsModel.nullable(),
   actualWorkStartDateTime: z.string(),

--- a/server/models/view-models/alcoholMonitoring/equipmentDetails.ts
+++ b/server/models/view-models/alcoholMonitoring/equipmentDetails.ts
@@ -20,7 +20,6 @@ const createViewModelFromApiDto = (
 
       return {
         legacySubjectId: details.legacySubjectId,
-        legacyOrderId: details.legacyOrderId,
         isoDateTime: details.deviceInstalledDateTime,
         dateTime,
         date: dateTime?.toDateString(),


### PR DESCRIPTION
- Remove legacyOrderId from paths that don't need it
- In a previous commit the curfew timetable path was renamed to service details. The API has now been updated to also use this name. This PR updates the API endpoint URL, & some tests.